### PR TITLE
Add extra guard for null values

### DIFF
--- a/src/UploadFieldPlugin.js
+++ b/src/UploadFieldPlugin.js
@@ -133,7 +133,7 @@ module.exports = function UploadFieldPlugin(
                 const upload = await obj[key];
                 obj[key] = await uploadResolversByFieldName[key](upload, args);
               }
-            } else if (typeof obj[key] === "object") {
+            } else if (obj[key] !== null && typeof obj[key] === "object") {
               await resolvePromises(obj[key]);
             }
           }


### PR DESCRIPTION
Currently, passing a null value into e.g. an update patch input causes the upload field plugin to throw an error that `Object.keys(null)` is not a thing. This adds a guard `obj[key] !== null` to fix this! :)