### PR TITLE
Expose PostGraphile attribute in context

### DIFF
--- a/src/UploadFieldPlugin.js
+++ b/src/UploadFieldPlugin.js
@@ -91,7 +91,10 @@ module.exports = function UploadFieldPlugin(
         }
         if (defs.length === 1) {
           const fieldName = inflection.column(attr);
-          memo[fieldName] = defs[0].resolve;
+          memo[fieldName] = {
+            resolve: defs[0].resolve,
+            attribute: attr
+          };
         }
         return memo;
       }, {});
@@ -108,11 +111,13 @@ module.exports = function UploadFieldPlugin(
             if (obj[key] instanceof Promise) {
               if (uploadResolversByFieldName[key]) {
                 const upload = await obj[key];
-                // eslint-disable-next-line require-atomic-updates
-                obj[key] = await uploadResolversByFieldName[key](
+                obj[key] = await uploadResolversByFieldName[key].resolve(
                   upload,
                   args,
-                  context,
+                  {
+                    ...context,
+                    attribute: uploadResolversByFieldName[key].attribute
+                  },
                   info
                 );
               }


### PR DESCRIPTION
I'd like to determine where to upload something to based on PostGraphile smart tags. I believe this is not possible currently. This PR will make that possible.

There's arguably a better name that can be used instead of `attribute` on the context.